### PR TITLE
Add info logging to messaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ node('aam-identity-prodcd') {
               "REGISTRY=${registry}",
               "COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}"
             ]) {
+              sh 'docker-compose down'
               parallel 'python34': {
                 sh "docker-compose run -e CODACY_PROJECT_TOKEN=${env.CODACY_PROJECT_TS_LIB_TOKEN} -e PYTHON_VERSION=34 python34 make install test codacy"
                 junit 'results-34.xml'

--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.1.1'
+__version__ = '1.1.2'

--- a/thunderstorm/messaging.py
+++ b/thunderstorm/messaging.py
@@ -79,6 +79,7 @@ def ts_task(event_name, schema):
                 )
                 raise SchemaError(error_msg, errors=errors, data=ts_message)
             else:
+                logger.info('received ts_task on {}'.format(event_name))
                 ts_message.data = deserialized_data
                 return task_func(ts_message)
 
@@ -126,6 +127,7 @@ def send_ts_task(event_name, schema, data):
 
         raise SchemaError(error_msg, errors=errors, data=data)
     else:
+        logger.info('send_ts_task on {}'.format(event_name))
         event = {
             'data': data
         }


### PR DESCRIPTION
Add a small log message whenever an event is received on ts_task or sent
with send_ts_task. Along with the request ID in every log message this
should be enough to determine whether a specific message went out.