### PR TITLE
Schema Error has an unproper representation

### DIFF
--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.1.5'
+__version__ = '1.1.6'

--- a/thunderstorm/messaging.py
+++ b/thunderstorm/messaging.py
@@ -95,7 +95,7 @@ class SchemaError(Exception):
         self.data = data
 
     def __str__(self):
-        return '{}: {}'.format(super().__str__(), self)
+        return '{}: {} with {}'.format(super().__str__(), self.errors, self.data)
 
 
 def send_ts_task(event_name, schema, data, **kwargs):


### PR DESCRIPTION
```
message = {}

    def task_handler(message):
        ts_message = TSMessage(message.pop('data'), message)
    
        deserialized_data, errors = schema.load(ts_message)
        if errors:
            statsd.incr('tasks.{}.ts_task.errors.schema'.format(task_name))
            error_msg = 'inbound schema validation error for event {}'.format(event_name)  # noqa
            logger.error(
                error_msg,
                extra={'errors': errors, 'data': ts_message}
            )
>           raise SchemaError(error_msg, errors=errors, data=ts_message)
E           thunderstorm.messaging.SchemaError: <unprintable SchemaError object>
```