### PR TITLE
[TSA-765] Use current_app.send_task

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 codacy-coverage
 pytest-cov>=2.5,<3
-pytest>=3.0,<4.0
+pytest>=3.0,<5.0
 flake8
 ipdb==0.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 celery>4,<5
 flask<2,>=0.12.3
 python-dateutil==2.6.1
-statsd==3.2.1
+statsd>=3.2.1,<4
 marshmallow>=2.15,<3

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -49,6 +49,22 @@ def flask_app(mock_query):
 
 
 @pytest.fixture
+def celery(celery_app):
+    celery_app.conf.broker_transport_options = {
+        'confirm_publish': True,  # optional, not affecting celery hang up
+        'max_retries': 3,
+        'interval_start': 0,
+        'interval_step': 0.1,
+        'interval_max': 0.2,
+    }
+
+    # set as current so the current_app proxy works
+    celery_app.set_current()
+
+    return celery_app
+
+
+@pytest.fixture
 def mock_query():
     query = MagicMock()
     query.count.return_value = 50

--- a/test/test_messaging.py
+++ b/test/test_messaging.py
@@ -67,10 +67,10 @@ def test_ts_task_fails_on_schema_error():
         my_task({'data': {'bar': 'foo'}, 'request_id': 123})
 
 
-@patch('thunderstorm.messaging.send_task')
-def test_send_ts_task_with_one(mock_send_task):
+def test_send_ts_task_with_one(celery):
     # act
-    send_ts_task('foo.bar', FooSchema(), {'foo': 'bar'})
+    with patch.object(celery, 'send_task') as mock_send_task:
+        send_ts_task('foo.bar', FooSchema(), {'foo': 'bar'})
 
     # assert
     mock_send_task.assert_called_once_with(
@@ -80,10 +80,10 @@ def test_send_ts_task_with_one(mock_send_task):
     )
 
 
-@patch('thunderstorm.messaging.send_task')
-def test_send_ts_task_with_many(mock_send_task):
+def test_send_ts_task_with_many(celery):
     # act
-    send_ts_task('foo.bar', FooSchema(many=True), [{'foo': 'bar'}])
+    with patch.object(celery, 'send_task') as mock_send_task:
+        send_ts_task('foo.bar', FooSchema(many=True), [{'foo': 'bar'}])
 
     # assert
     mock_send_task.assert_called_once_with(
@@ -93,34 +93,34 @@ def test_send_ts_task_with_many(mock_send_task):
     )
 
 
-@patch('thunderstorm.messaging.send_task')
-def test_send_ts_task_fails_on_schema_validation_failure(mock_send_task):
+def test_send_ts_task_fails_on_schema_validation_failure(celery):
     # assert
     with pytest.raises(SchemaError):
         # act
-        send_ts_task('foo.bar', FooSchema(many=False), {'bar': 'foo'})
+        with patch.object(celery, 'send_task') as mock_send_task:
+            send_ts_task('foo.bar', FooSchema(many=False), {'bar': 'foo'})
 
     # assert
     assert not mock_send_task.called
 
 
-@patch('thunderstorm.messaging.send_task')
-def test_send_ts_task_fails_on_one_when_expecting_many(mock_send_task):
+def test_send_ts_task_fails_on_one_when_expecting_many(celery):
     # assert
     with pytest.raises(SchemaError):
         # act
-        send_ts_task('foo.bar', FooSchema(many=True), {'foo': 'bar'})
+        with patch.object(celery, 'send_task') as mock_send_task:
+            send_ts_task('foo.bar', FooSchema(many=True), {'foo': 'bar'})
 
     # assert
     assert not mock_send_task.called
 
 
-@patch('thunderstorm.messaging.send_task')
-def test_send_ts_task_fails_on_many_when_expecting_one(mock_send_task):
+def test_send_ts_task_fails_on_many_when_expecting_one(celery):
     # assert
     with pytest.raises(SchemaError):
         # act
-        send_ts_task('foo.bar', FooSchema(many=False), [{'foo': 'bar'}])
+        with patch.object(celery, 'send_task') as mock_send_task:
+            send_ts_task('foo.bar', FooSchema(many=False), [{'foo': 'bar'}])
 
     # assert
     assert not mock_send_task.called

--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.2.0'
+__version__ = '1.3.0'

--- a/thunderstorm/messaging.py
+++ b/thunderstorm/messaging.py
@@ -2,8 +2,7 @@
 import collections
 
 from celery.utils.log import get_task_logger
-from celery.execute import send_task
-from celery import shared_task
+from celery import current_app, shared_task
 from statsd.defaults.env import statsd
 
 
@@ -137,7 +136,7 @@ def send_ts_task(event_name, schema, data, **kwargs):
         event = {
             'data': data
         }
-        return send_task(
+        return current_app.send_task(
             task_name,
             (event,),
             exchange='ts.messaging',


### PR DESCRIPTION
# FIX

* Moving away from `celery.execute` module as being deprecated