### PR TITLE
Bump dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 celery>4,<5
 flask<2,>=0.12.3
-python-dateutil==2.6.1
+python-dateutil>=2.6.1,<3
 statsd>=3.2.1,<4
 marshmallow>=3.0.0rc3,<4

--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '2.0.0'
+__version__ = '2.0.1'


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

## Description
Marshmallow uses dateutil to deserialize datetime objects if they are available: https://github.com/marshmallow-code/marshmallow/blob/f3f4734cf900761990deafbf1dc8ef53142880cd/marshmallow/utils.py#L258

`isoparse` was added to the parser module in `dateutil` 2.7.0: https://github.com/dateutil/dateutil/blame/d65738c34fe730648ea472794b268765062dcb9a/dateutil/parser/__init__.py

Increasing the minimum version of dateutil here to allow the agent service to install a newer version of dateutil to fix this issue