### PR TITLE
Handle errors

### DIFF
--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.4.4'
+__version__ = '1.4.5'


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

## Description
PR to help with the stability of faust agents. From time to time you will have exceptions which are expected to be raised in the normal course of events. This change lets you suppress a specified set of exceptions and just log an error for them instead.
