### PR TITLE
[feature] add custom metrics labeller

### DIFF
--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.4.5'
+__version__ = '1.4.6'

--- a/thunderstorm/kafka_messaging.py
+++ b/thunderstorm/kafka_messaging.py
@@ -41,7 +41,7 @@ class TSStatsdMonitor(StatsdMonitor):
 
     def _stream_label(self, stream: StreamT) -> str:
         """
-        Enhance original __styream_label function,
+        Enhance original _stream_label function
         it converts "topic_pos-week.fetch" -> "pos-week_fetch"
         """
         label = super()._stream_label(stream=stream)
@@ -162,7 +162,7 @@ class TSKafka(faust.App):
         except Exception as ex:
             raise TSKafkaConnectException(f'Exception while connecting to Kafka: {ex}')
 
-    def ts_event(self, event, log_only=(), *args, **kwargs):
+    def ts_event(self, event, catch_exc=(), *args, **kwargs):
         """Decorator for Thunderstorm messaging events
 
         Examples:
@@ -173,7 +173,7 @@ class TSKafka(faust.App):
         Args:
             topic (str): The topic name
             schema (marshmallow.Schema): The schema class expected by this task
-            log_only (tuple): Tuple of exception classes which can be
+            catch_exc (tuple): Tuple of exception classes which can be
                 logged as errors and then ignored
 
         Returns:
@@ -209,11 +209,8 @@ class TSKafka(faust.App):
 
                     try:
                         yield await func(deserialized_data)
-                    except Exception as ex:
-                        if isinstance(ex, log_only):
-                            logging.error(ex)
-                        else:
-                            raise
+                    except catch_exc as ex:
+                        logging.error(ex)
 
             return self.agent(topic, name=f'thunderstorm.messaging.{ts_task_name(topic)}')(event_handler)
 


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

* changing the exception handling done in `v1.4.5`
* using a custom label for faust builtin metrics, this is done to use the following patterns on telegraf:
```
    "ts.*.faust.topic.*.* measurement.service_name.library.measurement.topic_name.measurement*",
    "ts.*.faust.stream.*.events measurement.service_name.library.measurement.topic_name.measurement"
```
This is done because our topic names that we use on kafka have dots (`.`) in them which cause issues for kafka's custom metrics. Rather than redesign our topic names in a way that would require more effort and changes across all microservices we decided to use this workaround instead
