### PR TITLE
Fix/exception catching

### DIFF
--- a/test/test_kafka_messaging.py
+++ b/test/test_kafka_messaging.py
@@ -102,6 +102,38 @@ async def test_TSKafka_ts_event_calls_wrapped_function(kafka_app, TestEvent):
 
 
 @pytest.mark.asyncio
+async def test_TSKafka_ts_event_does_not_raise_if_catch_exc_set(kafka_app, TestEvent):
+    # arrange
+    message = {'data': {'int_1': 3, 'int_2': 6}}
+
+    # decorated agent
+    @kafka_app.ts_event(TestEvent, catch_exc=ValueError)
+    async def test_function(message):
+        raise ValueError()
+
+    # act
+    async with test_function.test_context() as agent:
+        await agent.put(message.copy())
+
+
+
+@pytest.mark.asyncio
+async def test_TSKafka_ts_event_raises_if_catch_exc_unset(kafka_app, TestEvent):
+    # arrange
+    message = {'data': {'int_1': 3, 'int_2': 6}}
+
+    # decorated agent
+    @kafka_app.ts_event(TestEvent)
+    async def test_function(message):
+        raise ValueError()
+
+    # act
+    async with test_function.test_context() as agent:
+        with pytest.raises(ValueError):
+            await agent.put(message.copy())
+
+
+@pytest.mark.asyncio
 async def test_TSKafka_ts_event_increases_metric_count_and_raises_SchemaError_for_bad_data(kafka_app, TestEvent):
     # arrange
     kafka_app.monitor = MagicMock()

--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.4.6'
+__version__ = '1.4.7'

--- a/thunderstorm/kafka_messaging.py
+++ b/thunderstorm/kafka_messaging.py
@@ -211,6 +211,7 @@ class TSKafka(faust.App):
                         yield await func(deserialized_data)
                     except catch_exc as ex:
                         logging.error(ex)
+                        yield
 
             return self.agent(topic, name=f'thunderstorm.messaging.{ts_task_name(topic)}')(event_handler)
 


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

# BUGFIX

* `yield` after cathing the exception in `ts_event` (yield None)`

the above is done to avoid getting errors on testing:

```
    message = {'data': {'int_1': 3, 'int_2': 6}}

    # decorated agent
    @kafka_app.ts_event(TestEvent)
    async def test_function(message):
        raise ValueError()

    # act
    async with test_function.test_context() as agent:
        with pytest.raises(ValueError):
            await agent.put(message.copy())

E               RuntimeError: Task <Task pending coro=<Agent._execute_task() running at /home/webapp/.local/share/virtualenvs/app-chdrSOfz/lib/python3.6/site-packages/faust/agents/agent.py:601> cb=[<TaskWakeupMethWrapper object at 0x7fd141f033d8>()]> got Future <Future pending> attached to a different loop
```

### this is on an aestetical change to make the `test_context` work while using pytest/unittest, no functionalities are affected by this