### PR TITLE
[fix] increase broker_request_timeout to 90

### DIFF
--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.4.7'
+__version__ = '1.4.8'

--- a/thunderstorm/kafka_messaging.py
+++ b/thunderstorm/kafka_messaging.py
@@ -70,6 +70,9 @@ class TSKafka(faust.App):
         self.broker = kwargs['broker']
         self.kafka_producer = None
         kwargs['broker'] = ';'.join([f'kafka://{broker}' for broker in kwargs['broker'].split(',')])
+        # overriding default value of 40.0 to make it bigger that the broker_session_timeout
+        # see https://github.com/robinhood/faust/issues/259#issuecomment-487907514
+        kwargs['broker_request_timeout'] = 90.0
         super().__init__(*args, **kwargs)
 
     def validate_data(self, data, event):


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

## Description

* Increasing `broker_request_timeout` to avoid hanging on topic rebalance https://github.com/robinhood/faust/issues/259#issuecomment-487907514
