### PR TITLE
[fix] add statsd metric pattern for kafka errors

### DIFF
--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.4.8'
+__version__ = '1.4.9'


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

Errors thrown on kafka agents will follow the pattern:
```
"ts.*.faust.stream.*.*.errors measurement.service_name.library.measurement.topic_name.error_type.measurement",
```