### PR TITLE
[release-dev] Fix/celery setup ts logger

### DIFF
--- a/thunderstorm/__init__.py
+++ b/thunderstorm/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'thunderstorm-library'
-__version__ = '1.7.2'
+__version__ = '1.7.3'

--- a/thunderstorm/kafka_messaging.py
+++ b/thunderstorm/kafka_messaging.py
@@ -6,7 +6,6 @@ import json
 import marshmallow  # TODO: @will-norris backwards compat - remove
 import sentry_sdk
 
-
 from faust.sensors.monitor import Monitor
 from faust.sensors.statsd import StatsdMonitor
 from faust.types import StreamT, TP, Message
@@ -20,7 +19,7 @@ from typing import Any
 from thunderstorm.logging import get_request_id
 from thunderstorm.shared import SchemaError, ts_task_name
 from thunderstorm.logging.kafka import KafkaRequestIDFilter
-from thunderstorm.logging import get_log_level
+from thunderstorm.logging import get_log_level, setup_ts_logger
 
 MARSHMALLOW_2 = int(marshmallow.__version__[0]) < 3
 
@@ -101,11 +100,14 @@ class TSKafka(App):
                 logging.warning('ts_log_level is not given, set to INFO as default.')
 
             try:
-                get_log_level(ts_log_level)   # for verify
+                get_log_level(ts_log_level)  # for verify
                 log_level = ts_log_level.upper()
             except ValueError as vex:
                 log_level = 'INFO'
                 logging.warning(f'{log_level} {vex}')
+
+            if kwargs.get('init_ts_logger'):
+                setup_ts_logger(ts_service, log_level)
 
             log_filter = KafkaRequestIDFilter()
             logger = logging.getLogger(ts_service)

--- a/thunderstorm/logging/celery.py
+++ b/thunderstorm/logging/celery.py
@@ -14,7 +14,7 @@ from celery.signals import setup_logging
 from celery._state import get_current_task
 
 from . import (
-    _register_id_getter, get_log_level, get_request_id,
+    _register_id_getter, setup_ts_logger, get_log_level, get_request_id,
     ts_json_handler, ts_stream_handler, TS_REQUEST_ID
 )
 
@@ -70,6 +70,10 @@ def init_app(
     ts_service = celery_app.conf['TS_SERVICE_NAME']
     ts_service = ts_service.replace('-', '_')
     log_level = get_log_level(celery_app.conf['TS_LOG_LEVEL'])
+
+    if init_ts_logger:
+        setup_ts_logger(ts_service, log_level)
+
     logger = logging.getLogger(ts_service)
     log_filter = CeleryTaskFilter()
     logger.addFilter(log_filter)


### PR DESCRIPTION
@artsalliancemedia/thunderstorm

[TSA-X](https://artsalliancemedia.atlassian.net/browse/TSA-X)

## Description
背景：大部分的服务以entrypoint为入口，会通过 flask 执行 setup_ts_logger 初始化 ts_logger。title-srv的入口没有统一，导致 kafka/celery 没有初始化 ts_logger。
+ 补充 logging/celery.py  里面 init_ts_logger 的逻辑
+ kakfa 亦加上可选 init_ts_logger 的参数